### PR TITLE
Fix EvalAI#1690:Updated to add support for monthly max submission limit

### DIFF
--- a/challenge_config.yaml
+++ b/challenge_config.yaml
@@ -28,6 +28,7 @@ challenge_phases:
     test_annotation_file: annotations/test_annotations_devsplit.json
     codename: dev
     max_submissions_per_day: 5
+    max_submissions_per_month: 15
     max_submissions: 50
   - id: 2
     name: Test Phase
@@ -39,6 +40,7 @@ challenge_phases:
     test_annotation_file: annotations/test_annotations_testsplit.json
     codename: test
     max_submissions_per_day: 5
+    max_submissions_per_month: 10
     max_submissions: 50
 
 dataset_splits:


### PR DESCRIPTION
Added new field `max_submissions_per_month`.