### PR TITLE
Add leaderboard_decimal_precision field in challenge config

### DIFF
--- a/challenge_config.yaml
+++ b/challenge_config.yaml
@@ -57,14 +57,17 @@ challenge_phase_splits:
     leaderboard_id: 1
     dataset_split_id: 1
     visibility: 1
+    leaderboard_decimal_precision: 2
     is_leaderboard_order_descending: True
   - challenge_phase_id: 2
     leaderboard_id: 1
     dataset_split_id: 1
     visibility: 3
+    leaderboard_decimal_precision: 2
     is_leaderboard_order_descending: True
   - challenge_phase_id: 2
     leaderboard_id: 1
     dataset_split_id: 2
     visibility: 1
+    leaderboard_decimal_precision: 2
     is_leaderboard_order_descending: True


### PR DESCRIPTION
### Changes proposed in this pull request:

- Added field `leaderboard_decimal_precision` under `challenge_phase_split` in challenge config file and by default set it to 2