### PR TITLE
Fix broken link to challenge creation documentation

### DIFF
--- a/challenge_config.yaml
+++ b/challenge_config.yaml
@@ -1,5 +1,5 @@
 # If you are not sure what all these fields mean, please refer our documentation here:
-# http://evalai.readthedocs.io/en/latest/challenge_creation.html#challenge-creation-using-zip-configuration
+# https://evalai.readthedocs.io/en/latest/configuration.html
 title: Random Number Generator Challenge
 short_description: Random number generation challenge for each submission
 description: templates/description.html


### PR DESCRIPTION
Update broken link:
- http://evalai.readthedocs.io/en/latest/challenge_creation.html#challenge-creation-using-zip-configuration -> https://evalai.readthedocs.io/en/latest/configuration.html