### PR TITLE
Add submission meta attributes to challenge phases.

### DIFF
--- a/challenge_config.yaml
+++ b/challenge_config.yaml
@@ -46,7 +46,7 @@ challenge_phases:
         type: radio
         options: ["A", "B", "C"]
       - name: MultipleChoiceAttribute
-        description: "Sample"
+        description: Sample
         type: checkbox
         options: ["alpha", "beta", "gamma"]
       - name: TrueFalseField
@@ -74,7 +74,7 @@ challenge_phases:
         type: radio
         options: ["A", "B", "C"]
       - name: MultipleChoiceAttribute
-        description: "Sample"
+        description: Sample
         type: checkbox
         options: ["alpha", "beta", "gamma"]
       - name: TrueFalseField

--- a/challenge_config.yaml
+++ b/challenge_config.yaml
@@ -37,6 +37,21 @@ challenge_phases:
     max_submissions_per_day: 5
     max_submissions_per_month: 50
     max_submissions: 50
+    submission_meta_attributes:
+      - name: TextAttribute
+        description: Sample
+        type: text
+      - name: SingleOptionAttribute
+        description: Sample
+        type: radio
+        options: ["A", "B", "C"]
+      - name: MultipleChoiceAttribute
+        description: "Sample"
+        type: checkbox
+        options: ["alpha", "beta", "gamma"]
+      - name: TrueFalseField
+        description: Sample
+        type: boolean
   - id: 2
     name: Test Phase
     description: templates/challenge_phase_2_description.html
@@ -50,6 +65,21 @@ challenge_phases:
     max_submissions_per_day: 5
     max_submissions_per_month: 50
     max_submissions: 50
+    submission_meta_attributes:
+      - name: TextAttribute
+        description: Sample
+        type: text
+      - name: SingleOptionAttribute
+        description: Sample
+        type: radio
+        options: ["A", "B", "C"]
+      - name: MultipleChoiceAttribute
+        description: "Sample"
+        type: checkbox
+        options: ["alpha", "beta", "gamma"]
+      - name: TrueFalseField
+        description: Sample
+        type: boolean
 
 dataset_splits:
   - id: 1


### PR DESCRIPTION
@RishabhJain2018 

This PR adds examples for submission meta attributes to the challenge phases in the challenge config file for challenge hosts.