### PR TITLE
Add allowed submission types field in challenge phase

### DIFF
--- a/challenge_config.yaml
+++ b/challenge_config.yaml
@@ -56,6 +56,7 @@ challenge_phases:
         required: True
     is_restricted_to_select_one_submission: False
     is_partial_submission_evaluation_enabled: False
+    allowed_submission_file_types: ".json, .zip, .txt, .tsv, .gz, .csv, .h5, .npy, .npz"
   - id: 2
     name: Test Phase
     description: templates/challenge_phase_2_description.html


### PR DESCRIPTION
### Description

Adds an example of `allowed_submission_file_type` field usage. 