### PR TITLE
update run.sh file to ignore extra files and folders while zipping

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ rm challenge_config.zip
 
 # Create new zip configuration according the updated code
 zip -r -j evaluation_script.zip evaluation_script/*  -x "*.DS_Store"
-zip -r challenge_config.zip *  -x "*.DS_Store" -x "evaluation_script/*" -x "*.git" -x "run.sh"
+zip -r challenge_config.zip *  -x "*.DS_Store" -x "evaluation_script/*" -x "*.git" -x "run.sh" -x "code_upload_challenge_evaluation/*" -x "worker/*" -x "challenge_data/*" -x "github/*" -x ".github/*" -x "README.md"


### PR DESCRIPTION
This PR --
- [x] Update `run.sh` to ignore `code_upload_challenge_evaluation`, `worker`, `challenge_data`, `github`, `. github` folders and `README` file.
