### PR TITLE
Add code upload challenge evaluation folder in ignore directory

### DIFF
--- a/github/config.py
+++ b/github/config.py
@@ -8,7 +8,7 @@ CHALLENGE_CONFIG_VALIDATION_URL = "/api/challenges/challenge/challenge_host_team
 CHALLENGE_CREATE_OR_UPDATE_URL = "/api/challenges/challenge/challenge_host_team/{}/create_or_update_github_challenge/"
 EVALAI_ERROR_CODES = [400, 401, 406]
 API_HOST_URL = "https://eval.ai"
-IGNORE_DIRS = [".git", ".github", "github"]
+IGNORE_DIRS = [".git", ".github", "github", "code_upload_challenge_evaluation"]
 IGNORE_FILES = [
     ".gitignore",
     "challenge_config.zip",


### PR DESCRIPTION
This PR --
- [x] Add `code_upload_challenge_evaluation` directory in `IGNORE_DIRS` for challenge config.
- [x] Fixes this error -- https://github.com/Ram81/test-challenge/pull/1/checks?check_run_id=1526149833