### PR TITLE
Add production and staging host URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ If you are looking for a simple challenge configuration that you can replicate t
 4. Now, go to [EvalAI](https://eval.ai) to fetch the following details -
    1. `evalai_user_auth_token` - Go to [profile page](https://eval.ai/web/profile) after logging in and click on `Get your Auth Token` to copy your auth token.
    2. `host_team_pk` - Go to [host team page](https://eval.ai/web/challenge-host-teams) and copy the `ID` for the team you want to use for challenge creation.
+   3. `evalai_host_url` - Use `https://eval.ai` for production server and `https://staging.eval.ai` for staging server.
 
 5. Create a branch with name `challenge` in the forked repository from the `master` branch.
 <span style="color:purple">Note: Only changes in `challenge` branch will be synchronized with challenge on EvalAI.</span>

--- a/github/host_config.json
+++ b/github/host_config.json
@@ -1,5 +1,5 @@
 {
 	"token": "<evalai_user_auth_token>",
 	"team_pk": "<host_team_pk>",
-	"evalai_host_url": "https://eval.ai"
+	"evalai_host_url": "<evalai_host_url>"
 }


### PR DESCRIPTION
This PR --
- [x] Remove hardcoded production URL for GitHub based challenge creation.
- [x] Add instructions to configure staging and production backend URL.