### PR TITLE
Move GitHub challenge creation to top and fix header in remote evalua…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,6 @@ If you are looking for a simple challenge configuration that you can replicate t
 │   └── run.py                                  # Contains the code to run the evaluation locally
 ```
 
-## Create challenge using config
-
-1. Fork this repository.
-
-2. Read [EvalAI challenge creation documentation](https://evalai.readthedocs.io/en/latest/configuration.html) to know more about how you want to structure your challenge. Once you are ready, start making changes in the yaml file, HTML templates, evaluation script according to your need.
-
-3. Once you are done making changes, run the command `./run.sh` to generate the `challenge_config.zip`.
-
-4. Upload the `challenge_config.zip` on [EvalAI](https://eval.ai) to create a challenge on EvalAI. Challenge will be available publicly once EvalAI Admin approves the challenge.
-   
-5. To update the challenge on EvalAI, use the UI to update the details.
-
 ## Create challenge using github
 
 1. Use this repository as [template](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template).
@@ -72,6 +60,18 @@ If you are looking for a simple challenge configuration that you can replicate t
 10. Go to [Hosted Challenges](https://eval.ai/web/hosted-challenges) to view your challenge. The challenge will be publicly available once EvalAI admin approves the challenge.
 
 11. To update the challenge on EvalAI, make changes in the repository and push on `challenge` branch and wait for the build to complete.
+
+## Create challenge using config
+
+1. Fork this repository.
+
+2. Read [EvalAI challenge creation documentation](https://evalai.readthedocs.io/en/latest/configuration.html) to know more about how you want to structure your challenge. Once you are ready, start making changes in the yaml file, HTML templates, evaluation script according to your need.
+
+3. Once you are done making changes, run the command `./run.sh` to generate the `challenge_config.zip`.
+
+4. Upload the `challenge_config.zip` on [EvalAI](https://eval.ai) to create a challenge on EvalAI. Challenge will be available publicly once EvalAI Admin approves the challenge.
+
+5. To update the challenge on EvalAI, use the UI to update the details.
 
 ## Test your evaluation script locally
 

--- a/remote_challenge_evaluation/evaluation_script_starter.py
+++ b/remote_challenge_evaluation/evaluation_script_starter.py
@@ -36,10 +36,7 @@ class EvalAI_Interface:
         Returns:
             [dict]: Authorization header
         """
-        # headers = {"Authorization": "Token {}".format(self.AUTH_TOKEN)} # For use with production server i.e. https://eval.ai
-        headers = {
-            "Authorization": "Bearer {}".format(self.AUTH_TOKEN)
-        }  # For use with staging server i.e. https://staging.eval.ai
+        headers = {"Authorization": "Bearer {}".format(self.AUTH_TOKEN)}
         return headers
 
     def make_request(self, url, method, data=None):


### PR DESCRIPTION
This PR --
- [x] Move challenge creation using GitHub as the first method.
- [x] Fix header in the remote challenge evaluation script for production. 