### PR TITLE
Fix run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,5 +5,7 @@ rm evaluation_script.zip
 rm challenge_config.zip
 
 # Create new zip configuration according the updated code
-zip -r -j evaluation_script.zip evaluation_script/*  -x "*.DS_Store"
+cd evaluation_script
+zip -r ../evaluation_script.zip * -x "*.DS_Store"
+cd ..
 zip -r challenge_config.zip *  -x "*.DS_Store" -x "evaluation_script/*" -x "*.git" -x "run.sh" -x "code_upload_challenge_evaluation/*" -x "remote_challenge_evaluation/*" -x "worker/*" -x "challenge_data/*" -x "github/*" -x ".github/*" -x "README.md"


### PR DESCRIPTION
Context: 

Currently, the challenge creation using `challenge_config.zip` requires the `evaluation_script.zip` to be without the outer-level directory. This PR fixes it.