### PR TITLE
Set ubuntu version 20.04 for workflow

### DIFF
--- a/.github/workflows/process_challenge.yml
+++ b/.github/workflows/process_challenge.yml
@@ -10,13 +10,13 @@ on:
     branches: [challenge]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.0
+          python-version: 3.7.5
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/process_challenge.yml
+++ b/.github/workflows/process_challenge.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.5
+          python-version: 3.8.0
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This PR changes Ubuntu version for the workflow to 20.04 due to this issue: https://github.com/actions/setup-python/issues/162.

We can move back to `ubuntu-latest` once the issue is addressed.