### PR TITLE
FIX#4324: Add verbose errors during init in evaluate method #4324

### DIFF
--- a/evaluation_script/__init__.py
+++ b/evaluation_script/__init__.py
@@ -22,12 +22,12 @@ def install(package):
             "install",
             package
         ])
-    except subprocess.CalledProcessError as e:
-        print("Error installing package:", e)
     except FileNotFoundError:
         print("Error: Pip not found.")
     except PermissionError:
         print("Error: Permission denied. ")
+    except subprocess.CalledProcessError as e:
+        print("Error installing package:", e)
 
 def install_local_package(folder_name):
     # Install a local python package
@@ -45,12 +45,12 @@ def install_local_package(folder_name):
             os.path.join(str(Path(__file__).parent.absolute()) + folder_name),
         ]
     )
-    except subprocess.CalledProcessError as e:
-        print("Error installing local package:", e)
     except FileNotFoundError:
         print("Error: Pip not found.")
     except PermissionError:
         print("Error: Permission denied. ")
+    except subprocess.CalledProcessError as e:
+        print("Error installing local package:", e)
 
 
 install("shapely==1.7.1")

--- a/evaluation_script/__init__.py
+++ b/evaluation_script/__init__.py
@@ -13,25 +13,45 @@ def install(package):
 
     # Args:
     #     package ([str]): Package name with version
-    
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
 
+    try:
+        subprocess.check_call([
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            package
+        ])
+    except subprocess.CalledProcessError as e:
+        print("Error installing package:", e)
+    except FileNotFoundError:
+        print("Error: Pip not found.")
+    except PermissionError:
+        print("Error: Permission denied. ")
 
 def install_local_package(folder_name):
     # Install a local python package
 
     # Args:
     #     folder_name ([str]): name of the folder placed in evaluation_script/
-    
-    subprocess.check_output(
-    [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        os.path.join(str(Path(__file__).parent.absolute()) + folder_name),
-    ]
-)
+
+    try:
+        subprocess.check_output(
+        [
+           sys.executable,
+            "-m",
+            "pip",
+            "install",
+            os.path.join(str(Path(__file__).parent.absolute()) + folder_name),
+        ]
+    )
+    except subprocess.CalledProcessError as e:
+        print("Error installing local package:", e)
+    except FileNotFoundError:
+        print("Error: Pip not found.")
+    except PermissionError:
+        print("Error: Permission denied. ")
+
 
 install("shapely==1.7.1")
 install("requests==2.25.1")


### PR DESCRIPTION
Added Some errors to be shown when the pip installation fails