### PR TITLE
Fix #4324: Add verbose output for pip install errors

### DIFF
--- a/evaluation_script/__init__.py
+++ b/evaluation_script/__init__.py
@@ -13,8 +13,14 @@ def install(package):
 
     # Args:
     #     package ([str]): Package name with version
-    
-    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+    try:
+        subprocess.run([sys.executable,"-m","pip","install",package])
+    except subprocess.CalledProcessError as e:
+        print(f"Error occurred while installing {package}: {e.stderr}")
+    except FileNotFoundError:
+        print("Error: Pip is not found. make sure you have pip installed.")
+    except PermissionError:
+        print("Error: Permission denied. ")
 
 
 def install_local_package(folder_name):
@@ -23,15 +29,22 @@ def install_local_package(folder_name):
     # Args:
     #     folder_name ([str]): name of the folder placed in evaluation_script/
     
-    subprocess.check_output(
-    [
-        sys.executable,
-        "-m",
-        "pip",
-        "install",
-        os.path.join(str(Path(__file__).parent.absolute()) + folder_name),
-    ]
-)
+    
+    try:
+        subprocess.run([
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            os.path.join(str(Path(__file__).parent.absolute()), folder_name)
+        ], capture_output=True, text=True, check=True)
+        print(f"Successfully installed local package from {folder_name}.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error occurred while installing local package from {folder_name}: {e.stderr}")
+    except FileNotFoundError:
+        print("Error: Pip not found.")
+    except PermissionError:
+        print("Error: Permission denied. ")
 
 install("shapely==1.7.1")
 install("requests==2.25.1")


### PR DESCRIPTION
This PR resolves Cloud-CV/EvalAI#4324


Since we're using **Python 3.7.5** in EvalAI-Starters, we can use **subprocess.run** instead of **.check_call.** This will allow us to capture the output and standard error output, making it more specific and verbose. 

Here's how it will look:
In this, I used the wrong module name and the wrong package name.

![image](https://github.com/Cloud-CV/EvalAI-Starters/assets/48647625/9bf0418a-0c8a-49d2-aab0-00175b0e49fb)

This way, we can make it easier to debug.

