### PR TITLE
Remove domain key from challenge config.

### DIFF
--- a/challenge_config.yaml
+++ b/challenge_config.yaml
@@ -18,10 +18,6 @@ tags:
   - machine-learning
   - data-science
   - computer-vision
-domain:
-  - computer-vision
-  - machine-learning
-  - data-science
 leaderboard:
   - id: 1
     schema:


### PR DESCRIPTION
Removed domain key due to this error: https://github.com/Cloud-CV/EvalAI-Starters/issues/100