### PR TITLE
Fix #105: Add GitHub action for host_config.json details check

### DIFF
--- a/.github/issue_templates/invalid_host_config.md
+++ b/.github/issue_templates/invalid_host_config.md
@@ -1,0 +1,9 @@
+## 🛠️ Configuration Error: Placeholder values detected in `host_config.json`
+
+This file still includes default placeholders like:
+
+- `<evalai_user_auth_token>`
+- `<host_team_pk>`
+- `<evalai_host_url>`
+
+Please replace them with real values to proceed.

--- a/.github/workflows/process_challenge.yml
+++ b/.github/workflows/process_challenge.yml
@@ -3,16 +3,8 @@
 
 name: evalai-challenge
 on:
-  push:
-    branches: [challenge]
-  pull_request:
-    types: [opened, synchronize, reopened, edited]
-    branches: [challenge]
-  workflow_run:
-    workflows: ["Validate host_config.json"]
-    types:
-      - completed
-      
+  workflow_call:
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/process_challenge.yml
+++ b/.github/workflows/process_challenge.yml
@@ -3,11 +3,11 @@
 
 name: evalai-challenge
 on:
-  push:
-    branches: [challenge]
-  pull_request:
-    types: [opened, synchronize, reopened, edited]
-    branches: [challenge]
+  workflow_run:
+    workflows: ["Validate host_config.json"]
+    types:
+      - completed
+      
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/process_challenge.yml
+++ b/.github/workflows/process_challenge.yml
@@ -3,6 +3,11 @@
 
 name: evalai-challenge
 on:
+  push:
+    branches: [challenge]
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [challenge]
   workflow_run:
     workflows: ["Validate host_config.json"]
     types:

--- a/.github/workflows/validate-host-config.yml
+++ b/.github/workflows/validate-host-config.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - challenge
-    paths:
-      - 'host_config.json'
   workflow_dispatch:
 
 jobs:
@@ -18,15 +16,15 @@ jobs:
       - name: Validate host_config.json
         id: validate
         run: |
-          if ! [ -f "host_config.json" ]; then
-            echo "host_config.json not found"
+          if ! [ -f "github/host_config.json" ]; then
+            echo "host_config.json not found in github/ directory"
             echo "invalid=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          TOKEN=$(jq -r '.token' host_config.json)
-          TEAM_PK=$(jq -r '.team_pk' host_config.json)
-          HOST_URL=$(jq -r '.evalai_host_url' host_config.json)
+          TOKEN=$(jq -r '.token' github/host_config.json)
+          TEAM_PK=$(jq -r '.team_pk' github/host_config.json)
+          HOST_URL=$(jq -r '.evalai_host_url' github/host_config.json)
 
           if [[ "$TOKEN" == "<evalai_user_auth_token>" || \
                 "$TEAM_PK" == "<host_team_pk>" || \
@@ -47,4 +45,5 @@ jobs:
           labels: |
             bug
             config
-
+  call-evalai-challenge:
+    uses: ./.github/workflows/process_challenge.yml      

--- a/.github/workflows/validate-host-config.yml
+++ b/.github/workflows/validate-host-config.yml
@@ -1,0 +1,47 @@
+name: Validate host_config.json
+
+on:
+  push:
+    paths:
+      - 'host_config.json'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Validate host_config.json
+        id: validate
+        run: |
+          if ! [ -f "host_config.json" ]; then
+            echo "host_config.json not found"
+            echo "invalid=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          TOKEN=$(jq -r '.token' host_config.json)
+          TEAM_PK=$(jq -r '.team_pk' host_config.json)
+          HOST_URL=$(jq -r '.evalai_host_url' host_config.json)
+
+          if [[ "$TOKEN" == "<evalai_user_auth_token>" || \
+                "$TEAM_PK" == "<host_team_pk>" || \
+                "$HOST_URL" == "<evalai_host_url>" ]]; then
+            echo "Invalid placeholders found"
+            echo "invalid=true" >> $GITHUB_OUTPUT
+          else
+            echo "All values are valid"
+            echo "invalid=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create issue if invalid
+        if: steps.validate.outputs.invalid == 'true'
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: "host_config.json needs real credentials"
+          content-file: .github/issue_templates/invalid_host_config.md
+          labels: |
+            bug
+            config

--- a/.github/workflows/validate-host-config.yml
+++ b/.github/workflows/validate-host-config.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - challenge
+    paths:
+      - 'host_config.json'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/validate-host-config.yml
+++ b/.github/workflows/validate-host-config.yml
@@ -2,6 +2,8 @@ name: Validate host_config.json
 
 on:
   push:
+    branches:
+      - challenge
     paths:
       - 'host_config.json'
   workflow_dispatch:
@@ -41,7 +43,8 @@ jobs:
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: "host_config.json needs real credentials"
-          content-file: .github/issue_templates/invalid_host_config.md
+          content-filepath: .github/issue_templates/invalid_host_config.md
           labels: |
             bug
             config
+

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ In order to test the evaluation script locally before uploading it to [EvalAI](h
 
 3. Run the command `python -m worker.run` from the directory where `annotations/` `challenge_data/` and `worker/` directories are present. If the command runs successfully, then the evaluation script works locally and will work on the server as well.
 
+## Important Note
+`host_config.json` file includes default placeholders like:
+
+- `<evalai_user_auth_token>`
+- `<host_team_pk>`
+- `<evalai_host_url>`
+
+Please replace them with real values before pushing changes to avoid build errors.
+
 ## Facing problems in creating a challenge?
 
 Please feel free to open issues on our [GitHub Repository](https://github.com/Cloud-CV/EvalAI-Starter/issues) or contact us at team@cloudcv.org if you have issues.


### PR DESCRIPTION
## Description
This PR adds the following measures to check the host_config.json missing details:
1. A GitHub workflow `validate-host-config.yml` that checks if `host_config.json` have placeholders instead of real values and creates an issue as per the `invalid_host_config.md` issue template if `host_config.json` details are invalid.
3. A note in `README.md` that reminds users to replace the placeholders.

fixes #105 