### PR TITLE
Fix(utils): Updates token expiration error logic in EvalAI API response

### DIFF
--- a/github/utils.py
+++ b/github/utils.py
@@ -177,7 +177,7 @@ def validate_token(response):
             print(error)
             os.environ["CHALLENGE_ERRORS"] = error
             return False
-        if response.get("code") == "token_not_valid":
+        if response["detail"] == "Given token not valid for any token type":
             error = "\nThe token is invalid or expired. Please generate it again.\n"
             print(error)
             os.environ["CHALLENGE_ERRORS"] = error

--- a/github/utils.py
+++ b/github/utils.py
@@ -177,4 +177,9 @@ def validate_token(response):
             print(error)
             os.environ["CHALLENGE_ERRORS"] = error
             return False
+        if response.get("code") == "token_not_valid":
+            error = "\nThe token is invalid or expired. Please generate it again.\n"
+            print(error)
+            os.environ["CHALLENGE_ERRORS"] = error
+            return False
     return True


### PR DESCRIPTION
## Description
Currently, EvalAI API handles authentication token checks using DRF's authentication classes (`JWTAuthentication` and `ExpiringTokenAuthentication`). When an error exception occurs,  e.g., while using an expired `HOST_AUTH_TOKEN`, then the EvalAI API's authentication class returns the following response:

```json
{
  "detail": "Given token not valid for any token type",
  "code": "token_not_valid",
  "messages": [
    {
      "token_class": "RefreshToken",
      "token_type": "refresh",
      "message": "Token is invalid or expired"
    }
  ]
}
```

However, the `validate_token` function in `utils.py` of the starter repo only expects errors with either of the following `detail` values:
`"Invalid token"`
`"Token has expired"`

Due to this, the `challenge_processing_script` was returning a vague error message like `401 Client Error: ....`.

This PR fixes the `validate_token` function to expect the exact error `"code"` that the API is actually returning in its response when token is expired/invalid.

## Results
Testing the updated logic with an "intentionally" bad token.

https://github.com/user-attachments/assets/ff5afe29-c5d8-461d-b826-5ec600a780ec

Fixes [https://github.com/Cloud-CV/EvalAI/issues/4644](https://github.com/Cloud-CV/EvalAI/issues/4644)