### PR TITLE
Docs: Removes references of deprecated ZIP method for challenge creation from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ If you are looking for a simple challenge configuration that you can replicate t
 │   └── main.py                                 # Contains the main `evaluate()` method
 ├── logo.jpg                                    # Logo image of the challenge
 ├── submission.json                             # Sample submission file
-├── run.sh                                      # Script to create the challenge configuration zip to be uploaded on EvalAI website
 └── templates                                   # Contains challenge related HTML templates
     ├── challenge_phase_1_description.html      # Challenge Phase 1 description template
     ├── challenge_phase_2_description.html      # Challenge Phase 2 description template
@@ -61,18 +60,6 @@ If you are looking for a simple challenge configuration that you can replicate t
 10. Go to [Hosted Challenges](https://eval.ai/web/hosted-challenges) to view your challenge. The challenge will be publicly available once EvalAI admin approves the challenge.
 
 11. To update the challenge on EvalAI, make changes in the repository and push on `challenge` branch and wait for the build to complete.
-
-## Create challenge using config
-
-1. Fork this repository.
-
-2. Read [EvalAI challenge creation documentation](https://evalai.readthedocs.io/en/latest/configuration.html) to know more about how you want to structure your challenge. Once you are ready, start making changes in the yaml file, HTML templates, evaluation script according to your need.
-
-3. Once you are done making changes, run the command `./run.sh` to generate the `challenge_config.zip`.
-
-4. Upload the `challenge_config.zip` on [EvalAI](https://eval.ai) to create a challenge on EvalAI. Challenge will be available publicly once EvalAI Admin approves the challenge.
-
-5. To update the challenge on EvalAI, use the UI to update the details.
 
 ## Test your evaluation script locally
 


### PR DESCRIPTION
This PR removes all the references of the deprecated ZIP method for challenge creation from the README.

fixes https://github.com/Cloud-CV/EvalAI/issues/4651